### PR TITLE
fix: correctly handle axios response status

### DIFF
--- a/src/api/http.ts
+++ b/src/api/http.ts
@@ -124,7 +124,8 @@ class Http {
     // console.error('error data', error);
     if (isAxiosError(error)) {
       console.error("error data", JSON.stringify(error));
-      switch (error.status) {
+      const status = error.response?.status;
+      switch (status) {
         case StatusCode.InternalServerError: {
           // Handle InternalServerError
           break;


### PR DESCRIPTION
## Summary
- fix axios error handler to read status from response

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6896d71aa92883259b0b7ee8d670c515