### PR TITLE
fix: correct registry personalization text

### DIFF
--- a/src/i18n/locales/en/translations.ts
+++ b/src/i18n/locales/en/translations.ts
@@ -128,7 +128,7 @@ const translations = {
     newRegistry: "New registry",
     createregistry: "Create registry",
     letsCreateRegistry: "Let's create a registry that's uniquely yours!",
-    personalizaYourRegistry: "Personaliza your registry.",
+    personalizaYourRegistry: "Personalize your registry.",
     addPhotoGreeting: "Add a photo and a greeting.",
     title: "Title",
     titlePlaceholder: "Enter registry title",


### PR DESCRIPTION
## Summary
- fix personalizaYourRegistry translation text to use proper English

## Testing
- `npx tsc --noEmit src/i18n/locales/en/translations.ts`
- `npm test -- --watchAll=false` (fails: No tests found)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896d8d22a0883259c1cdf9d83e57d54