### PR TITLE
test: add formatPrice tests

### DIFF
--- a/src/utils/__tests__/helper.test.ts
+++ b/src/utils/__tests__/helper.test.ts
@@ -1,0 +1,15 @@
+import { formatPrice } from "../helper";
+
+describe("formatPrice", () => {
+  it("formats using default currency (KWD)", () => {
+    expect(formatPrice(10)).toBe("KWD\u00A010.00");
+  });
+
+  it("formats using a specified currency (USD)", () => {
+    expect(formatPrice(10, "USD")).toBe("$10.00");
+  });
+
+  it("falls back to a plain string when the currency code is invalid", () => {
+    expect(formatPrice(10, "INVALID")).toBe("INVALID 10.00");
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for formatPrice covering default KWD, custom USD and invalid codes

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896da57637083258f3a43b4b21d93f7